### PR TITLE
variadic column deletion added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <name>Cascading and Scalding wrapper for HBase with advanced features</name>
     <groupId>parallelai</groupId>
     <artifactId>parallelai.spyglass</artifactId>
-    <version>2.10_0.12.0_5.3.1</version>
+    <version>2.10_0.12.0_5.4.0</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -29,15 +29,15 @@
         <maven-scala-plugin.version>2.15.2</maven-scala-plugin.version>
         <maven.surefire.plugin.version>2.12.3</maven.surefire.plugin.version>
 
-        <cdh.version>cdh5.3.1</cdh.version>
+        <cdh.version>cdh5.4.0</cdh.version>
 
-        <hadoop.version>2.5.0-${cdh.version}</hadoop.version>
+        <hadoop.version>2.6.0-${cdh.version}</hadoop.version>
         <!-- <hadoop.core.version>2.5.0-${cdh.version}</hadoop.core.version> -->
-        <hbase.version>0.98.6-${cdh.version}</hbase.version>
+        <hbase.version>1.0.0-${cdh.version}</hbase.version>
 
         <!-- Scala/Scalding/Cascading properties -->
         <!-- can be 2.9.3 and 2.10.2 -->
-        <scala.version>2.10.3</scala.version>
+        <scala.version>2.10.4</scala.version>
         <!-- 2.10 for Scala 2.10.2 and 2.9.3 for Scala version 2.9.3 -->
         <scalding.scala.version>2.10</scalding.scala.version>
         <scalding.version>0.12.0</scalding.version>

--- a/src/main/java/parallelai/spyglass/hbase/HBaseOperation.java
+++ b/src/main/java/parallelai/spyglass/hbase/HBaseOperation.java
@@ -49,13 +49,13 @@ public abstract class HBaseOperation {
     }
 
     public static class DeleteRow extends HBaseOperation {
-        private DeleteRow() {
+        public DeleteRow() {
             super(OperationType.DELETE_ROW);
         }
     }
 
     static class NoOp extends HBaseOperation {
-        private NoOp() {
+        public NoOp() {
             super(OperationType.NO_OP);
         }
     }

--- a/src/main/java/parallelai/spyglass/hbase/HBaseOperation.java
+++ b/src/main/java/parallelai/spyglass/hbase/HBaseOperation.java
@@ -21,14 +21,30 @@ public abstract class HBaseOperation {
     }
 
     public static class DeleteColumn extends HBaseOperation {
-        private DeleteColumn() {
+        private String family;
+        private String column;
+        public DeleteColumn(String family, String column) {
             super(OperationType.DELETE_COLUMN);
+            this.family = family;
+            this.column = column;
+        }
+        public String getFamily(){
+            return family;
+        }
+        public String getColumn(){
+            return column;
         }
     }
 
     public static class DeleteFamily extends HBaseOperation {
-        private DeleteFamily() {
+        private String family;
+        public DeleteFamily(String family) {
             super(OperationType.DELETE_FAMILY);
+            this.family = family;
+        }
+
+        public String getFamily(){
+            return family;
         }
     }
 
@@ -44,10 +60,10 @@ public abstract class HBaseOperation {
         }
     }
 
-    public static final DeleteColumn DELETE_COLUMN = new DeleteColumn();
-    public static final DeleteFamily DELETE_FAMILY = new DeleteFamily();
-    public static final DeleteRow DELETE_ROW = new DeleteRow();
-    public static final NoOp NO_OP = new NoOp();
+    //public static final DeleteColumn DELETE_COLUMN = new DeleteColumn();
+   // public static final DeleteFamily DELETE_FAMILY = new DeleteFamily();
+    //public static final DeleteRow DELETE_ROW = new DeleteRow();
+    //public static final NoOp NO_OP = new NoOp();
 
     private final OperationType operationType;
 

--- a/src/main/java/parallelai/spyglass/hbase/HBaseOperation.java
+++ b/src/main/java/parallelai/spyglass/hbase/HBaseOperation.java
@@ -8,22 +8,32 @@ public abstract class HBaseOperation {
     }
 
     public static class PutColumn extends HBaseOperation {
+        private final String family;
+        private final String column;
         private final ImmutableBytesWritable value;
 
-        public PutColumn(final ImmutableBytesWritable value) {
+        public PutColumn(final String family, final String column, final ImmutableBytesWritable value) {
             super(OperationType.PUT_COLUMN);
             this.value = value;
+            this.family = family;
+            this.column = column;
         }
 
         public byte[] getBytes() {
             return value.get();
         }
+        public String getFamily(){
+            return family;
+        }
+        public String getColumn(){
+            return column;
+        }
     }
 
     public static class DeleteColumn extends HBaseOperation {
-        private String family;
-        private String column;
-        public DeleteColumn(String family, String column) {
+        private final String family;
+        private final String column;
+        public DeleteColumn(final String family, final String column) {
             super(OperationType.DELETE_COLUMN);
             this.family = family;
             this.column = column;
@@ -37,8 +47,8 @@ public abstract class HBaseOperation {
     }
 
     public static class DeleteFamily extends HBaseOperation {
-        private String family;
-        public DeleteFamily(String family) {
+        private final String family;
+        public DeleteFamily(final String family) {
             super(OperationType.DELETE_FAMILY);
             this.family = family;
         }

--- a/src/main/java/parallelai/spyglass/hbase/HBaseScheme.java
+++ b/src/main/java/parallelai/spyglass/hbase/HBaseScheme.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 
 import parallelai.spyglass.hbase.HBaseOperation.DeleteColumn;
 import parallelai.spyglass.hbase.HBaseOperation.DeleteFamily;
+import parallelai.spyglass.hbase.HBaseOperation.PutColumn;
 /**
  * The HBaseScheme class is a {@link Scheme} subclass. It is used in conjunction with the {@HBaseTap} to
  * allow for the reading and writing of data to and from a HBase cluster.
@@ -277,15 +278,16 @@ public class HBaseScheme
           HBaseOperation op = (HBaseOperation) item;
           switch(op.getType()) {
             case PUT_COLUMN:
-              put.add(Bytes.toBytes(familyNames[i]), Bytes.toBytes((String) fields.get(j)), ((HBaseOperation.PutColumn) item).getBytes());
+              PutColumn opp = (PutColumn) op;
+              put.add(Bytes.toBytes(opp.getFamily()), Bytes.toBytes(opp.getColumn()), opp.getBytes());
               break;
             case DELETE_COLUMN:
-              DeleteColumn _opc = (DeleteColumn) op;
-              delete.deleteColumns(Bytes.toBytes(_opc.getFamily()), Bytes.toBytes(_opc.getColumn()));
+              DeleteColumn opc = (DeleteColumn) op;
+              delete.deleteColumns(Bytes.toBytes(opc.getFamily()), Bytes.toBytes(opc.getColumn()));
               break;
             case DELETE_FAMILY:
-              DeleteFamily _opf = (DeleteFamily) op;
-              delete.deleteFamily(Bytes.toBytes(_opf.getFamily()));
+              DeleteFamily opf = (DeleteFamily) op;
+              delete.deleteFamily(Bytes.toBytes(opf.getFamily()));
               break;
             case DELETE_ROW:
               deleteRow = true;

--- a/src/main/java/parallelai/spyglass/hbase/HBaseScheme.java
+++ b/src/main/java/parallelai/spyglass/hbase/HBaseScheme.java
@@ -38,6 +38,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 
+import parallelai.spyglass.hbase.HBaseOperation.DeleteColumn;
+import parallelai.spyglass.hbase.HBaseOperation.DeleteFamily;
 /**
  * The HBaseScheme class is a {@link Scheme} subclass. It is used in conjunction with the {@HBaseTap} to
  * allow for the reading and writing of data to and from a HBase cluster.
@@ -278,10 +280,12 @@ public class HBaseScheme
               put.add(Bytes.toBytes(familyNames[i]), Bytes.toBytes((String) fields.get(j)), ((HBaseOperation.PutColumn) item).getBytes());
               break;
             case DELETE_COLUMN:
-              delete.deleteColumns(Bytes.toBytes(familyNames[i]), Bytes.toBytes((String) fields.get(j)));
+              DeleteColumn _opc = (DeleteColumn) op;
+              delete.deleteColumns(Bytes.toBytes(_opc.getFamily()), Bytes.toBytes(_opc.getColumn()));
               break;
             case DELETE_FAMILY:
-              delete.deleteFamily(Bytes.toBytes(familyNames[i]));
+              DeleteFamily _opf = (DeleteFamily) op;
+              delete.deleteFamily(Bytes.toBytes(_opf.getFamily()));
               break;
             case DELETE_ROW:
               deleteRow = true;

--- a/src/main/scala/parallelai/spyglass/hbase/HBaseConversions.scala
+++ b/src/main/scala/parallelai/spyglass/hbase/HBaseConversions.scala
@@ -18,7 +18,7 @@ class HBasePipeWrapper (pipe: Pipe) {
           }}
       }
     }
-  def toHBaseOperation(f: Fields): Pipe = {
+  /*def toHBaseOperation(f: Fields): Pipe = {
     asList(f)
       .foldLeft(pipe){ (p, f) => {
       p.map(f.toString -> f.toString){ from: String => from match {
@@ -29,7 +29,7 @@ class HBasePipeWrapper (pipe: Pipe) {
         case x => new HBaseOperation.PutColumn(new ImmutableBytesWritable(Bytes.toBytes(x)))
       }}
     }}
-  }
+  }*/
 
 	def fromBytesWritable(f: Fields): Pipe = {
 	  asList(f)


### PR DESCRIPTION
Unfortunatelly original feature does not provide variadic column removal depending on row. There are some cases when this is quite useful, so some changes were applied to HBaseOperartion and HBaseSchema classes in order to support this.
